### PR TITLE
Add note about provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ $ vagrant destroy
 $ vagrant up
 ...
 ```
+If virtualbox complains about an unsupported provider, make sure to have a working virtualbox and prefix the command with ``VAGRANT_DEFAULT_PROVIDER=virtualbox``:
+
+```
+$ VAGRANT_DEFAULT_PROVIDER=virtualbox vagrant up
+...
+```
 
 ## Compiling the latest PHP 7
 


### PR DESCRIPTION
Vagrant on Fedora has the default provider `libvirt` which does not work with this box.
