### PR TITLE
Adding check on database array

### DIFF
--- a/scripts/php7dev.rb
+++ b/scripts/php7dev.rb
@@ -64,11 +64,13 @@ class Php7dev
     end
 
     # Configure All Of The Configured Databases
-    settings["databases"].each do |db|
-        config.vm.provision "shell" do |s|
-            s.path = "./scripts/create-mysql.sh"
-            s.args = [db]
-        end
+    if settings['databases'].kind_of?(Array)
+      settings["databases"].each do |db|
+          config.vm.provision "shell" do |s|
+              s.path = "./scripts/create-mysql.sh"
+              s.args = [db]
+          end
+      end
     end
 
     # Update Composer On Every Provision


### PR DESCRIPTION
Adding a check to see if database config setting has any database names set. If end user does not need any MySQL databases and removes or comments out the database name, vagrant up will fail. This will prevent that from happening.
