### PR TITLE
Added additional sites

### DIFF
--- a/php7dev.yaml
+++ b/php7dev.yaml
@@ -18,5 +18,9 @@ folders:
 #    - map: example-folder
 #      to: /path/in/vagrant/example-folder
 
+sites:
+#    - hostname: example-site
+#      to: /home/vagrant/www/example-site
+
 databases:
     - example_database

--- a/scripts/clear-sites.sh
+++ b/scripts/clear-sites.sh
@@ -1,0 +1,37 @@
+sudo rm -f /etc/nginx/sites-enabled/*
+sudo rm -f /etc/nginx/sites-available/*
+
+nginxconf="
+
+user  www-data;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '\$remote_addr - \$remote_user [\$time_local] "\$request" '
+                      '\$status \$body_bytes_sent "\$http_referer" '
+                      '"\$http_user_agent" "\$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+    include /etc/nginx/conf.d/*.conf;
+}
+"
+sudo echo "$nginxconf" > "/etc/nginx/nginx.conf"

--- a/scripts/create-sites.sh
+++ b/scripts/create-sites.sh
@@ -1,0 +1,42 @@
+block="server {
+    listen 80;
+    server_name $1;
+    root \"$2\";
+    index  index.php index.html index.htm;
+    access_log  /var/log/nginx/default-access.log  main;
+    error_log   /var/log/nginx/default-error.log;
+
+    error_page   500 502 503 504  /50x.html;
+
+    location = /50x.html {
+        root   /var/www/default;
+    }
+
+
+    location / {
+        try_files \$uri \$uri/ @rewrite;
+    }
+
+    location @rewrite {
+        rewrite ^(.*)$ /index.php;
+    }
+
+    location ~ \.php$ {
+
+        include                  fastcgi_params;
+        fastcgi_keep_conn on;
+        fastcgi_index            index.php;
+        fastcgi_split_path_info  ^(.+\.php)(/.+)$;
+        fastcgi_param PATH_INFO \$fastcgi_path_info;
+        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+        fastcgi_intercept_errors on;
+        fastcgi_pass unix:/var/run/php-fpm.sock;
+    }
+
+}
+"
+sudo mkdir -p "/etc/nginx/sites-available" "/etc/nginx/sites-enabled"
+sudo echo "$block" > "/etc/nginx/sites-available/$1"
+sudo ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
+sudo service nginx restart
+sudo service php-fpm restart

--- a/scripts/php7dev.rb
+++ b/scripts/php7dev.rb
@@ -33,6 +33,24 @@ class Php7dev
         config.vm.network "forwarded_port", guest: port["guest"], host: port["host"], protocol: port["protocol"] ||= "tcp"
       end
     end
+
+    # Add Configured Nginx Sites
+    config.vm.provision "shell" do |s|
+        s.path = "./scripts/clear-sites.sh"
+    end
+
+    if settings['sites'].kind_of?(Array)
+      config.vm.provision "shell" do |s|
+        s.path = "./scripts/remake-nginxconf.sh"
+      end
+
+      settings["sites"].each do |site|
+        config.vm.provision "shell" do |s|
+          s.args = [site["hostname"], site["to"]]
+          s.path = "./scripts/create-sites.sh"
+        end
+      end
+    end
     
     if !Vagrant::Util::Platform.windows?
       # Configure The Public Key For SSH Access
@@ -79,3 +97,4 @@ class Php7dev
     end
   end
 end
+

--- a/scripts/remake-nginxconf.sh
+++ b/scripts/remake-nginxconf.sh
@@ -1,0 +1,35 @@
+nginxconf="
+
+user  www-data;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '\$remote_addr - \$remote_user [\$time_local] "\$request" '
+                      '\$status \$body_bytes_sent "\$http_referer" '
+                      '"\$http_user_agent" "\$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+    include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/sites-enabled/*;
+}
+"
+sudo echo "$nginxconf" > "/etc/nginx/nginx.conf"


### PR DESCRIPTION
you can add new sites from php7dev.yaml
add your sites under php7dev.yaml->sites

```
sites:
      - hostname: example-site
        to: /path/in/vagrant/example-site
```

and update your hosts file.
for example;

```
192.168.7.7 php7dev
192.168.7.7 example-site
```

when you add a site or sites, run:

```
vagrant reload --provision
```

If you have additional sites in yaml file,this adds their config file to nginx.conf as sites-available/*.
If you don't use any additional site,this changes nginx.conf with original version.
Both possibilities delete your additional changes from nginx.conf
