### PR TITLE
Added more options to configure shared folder's permissions

### DIFF
--- a/scripts/php7dev.rb
+++ b/scripts/php7dev.rb
@@ -77,7 +77,7 @@ class Php7dev
     # Register All Of The Configured Shared Folders
     if settings['folders'].kind_of?(Array)
       settings["folders"].each do |folder|
-        config.vm.synced_folder folder["map"], folder["to"], type: folder["type"] ||= nil
+        config.vm.synced_folder folder["map"], folder["to"], type: folder["type"], owner: folder["owner"], group: folder["group"], mount_options: folder["mount_options"] ||= nil
       end
     end
 


### PR DESCRIPTION
Added more options for the shared folders to allow setting owner/group/permissions on files/folders.

I needed to add this to my local VM to make a Symfony project to work in a shared folder, so did a PR in case it's useful for someone else - I have my project in my computer at `~/Projects/my-project`, and I sync it to the VM at `/var/www/my-project`.

With this change, you can have this in your `php7dev.yaml`:

```
folders:
    - map: /Users/me/Projects/my-project
      to: /var/www/my-project
      owner: www-data
      group: vagrant
      mount_options: [dmode=775, fmode=664]
```

The tests I did were just checking that when you add the options, they get applied, and when you don't, the defaults are applied. If you provide invalid values, it gets stuck for a while when trying to mount the shared folders and then fails, but the VM is created anyway.

Note: didn't add the parameters commented out to the `php7dev.yaml` file, because I saw the `type` option is usable and it's not in that file, so I did the same.
